### PR TITLE
Add vat_number check to TAX override controler

### DIFF
--- a/override/classes/tax/TaxRulesTaxManager.php
+++ b/override/classes/tax/TaxRulesTaxManager.php
@@ -51,7 +51,13 @@ class TaxRulesTaxManager extends TaxRulesTaxManagerCore
 
 				// Check if the customer is part of the no TAX group.
 				$hasNoTaxGroup = $vatchecker->hasNoTaxGroup( $this->address->id_customer );
-				if ( $hasNoTaxGroup ) {
+				
+				// Crezzur: Added additional check to see if vatnumber is not empty when user is in NoTaxGroup.
+				if ( $hasNoTaxGroup && !$this->address->vat_number ) {
+
+					$tax_enabled = null; // If no TAX number = Pay taxes
+
+				} else if ( $hasNoTaxGroup ) {
 
 					// Double-check if the address isn't the same as the origin country.
 					$isOriginCountry = $vatchecker->isOriginCountry( $this->address->id_country );


### PR DESCRIPTION
When you have entered a valid VAT-number you are added to the NoTaxGroup.
When you later remove this VAT-number from your address, for whatever reason, you will stay in the NoTaxGroup.
This way you are able to change country, address, ... without being removed from theNoTaxGroup (as long you don't add a new VAT-number our change your address to the VAT-origin country. 