### PR TITLE
v1.3.0 - Store validation in database and stop using groups

### DIFF
--- a/override/classes/tax/TaxRulesTaxManager.php
+++ b/override/classes/tax/TaxRulesTaxManager.php
@@ -46,18 +46,17 @@ class TaxRulesTaxManager extends TaxRulesTaxManagerCore
 			$tax_enabled = Configuration::get( 'PS_TAX' );
 		}
 
-		if ( $tax_enabled ) {
+		if ( $tax_enabled && $this->address ) {
 			/** @var Vatchecker $vatchecker */
 			$vatchecker = Module::getInstanceByName('vatchecker');
 			if ( $vatchecker ) {
 
-				// Check if the customer can order without VAT on the selected address.
-				$validVat = $vatchecker->isValidVat( $this->address, false );
-				if ( $validVat ) {
+				// Double-check if the address isn't the same as the origin country.
+				if ( ! $vatchecker->isOriginCountry( $this->address->id_country ) ) {
 
-					// Double-check if the address isn't the same as the origin country.
-					$isOriginCountry = $vatchecker->isOriginCountry( $this->address->id_country );
-					if ( ! $isOriginCountry ) {
+					// Check if the customer can order without VAT on the selected address.
+					$validVat = $vatchecker->isValidVat( $this->address, false );
+					if ( $validVat ) {
 
 						// Disable TAX.
 						$tax_enabled = false;

--- a/override/classes/tax/TaxRulesTaxManager.php
+++ b/override/classes/tax/TaxRulesTaxManager.php
@@ -49,19 +49,9 @@ class TaxRulesTaxManager extends TaxRulesTaxManagerCore
 		if ( $tax_enabled && $this->address ) {
 			/** @var Vatchecker $vatchecker */
 			$vatchecker = Module::getInstanceByName('vatchecker');
-			if ( $vatchecker ) {
-
-				// Double-check if the address isn't the same as the origin country.
-				if ( ! $vatchecker->isOriginCountry( $this->address->id_country ) ) {
-
-					// Check if the customer can order without VAT on the selected address.
-					$validVat = $vatchecker->isValidVat( $this->address, false );
-					if ( $validVat ) {
-
-						// Disable TAX.
-						$tax_enabled = false;
-					}
-				}
+			if ( $vatchecker && $vatchecker->canOrderWithoutVat( $this->address ) ) {
+				// Disable TAX.
+				$tax_enabled = false;
 			}
 		}
 

--- a/override/classes/tax/TaxRulesTaxManager.php
+++ b/override/classes/tax/TaxRulesTaxManager.php
@@ -51,9 +51,9 @@ class TaxRulesTaxManager extends TaxRulesTaxManagerCore
 			$vatchecker = Module::getInstanceByName('vatchecker');
 			if ( $vatchecker ) {
 
-				// Check if the customer is part of the no TAX group.
-				$hasNoTaxGroup = $vatchecker->hasNoTaxGroup( $this->address->id_customer );
-				if ( $hasNoTaxGroup ) {
+				// Check if the customer can order without VAT on the selected address.
+				$validVat = $vatchecker->isValidVat( $this->address );
+				if ( $validVat ) {
 
 					// Double-check if the address isn't the same as the origin country.
 					$isOriginCountry = $vatchecker->isOriginCountry( $this->address->id_country );

--- a/override/classes/tax/TaxRulesTaxManager.php
+++ b/override/classes/tax/TaxRulesTaxManager.php
@@ -52,7 +52,7 @@ class TaxRulesTaxManager extends TaxRulesTaxManagerCore
 			if ( $vatchecker ) {
 
 				// Check if the customer can order without VAT on the selected address.
-				$validVat = $vatchecker->isValidVat( $this->address );
+				$validVat = $vatchecker->isValidVat( $this->address, false );
 				if ( $validVat ) {
 
 					// Double-check if the address isn't the same as the origin country.

--- a/override/classes/tax/TaxRulesTaxManager.php
+++ b/override/classes/tax/TaxRulesTaxManager.php
@@ -43,10 +43,12 @@ class TaxRulesTaxManager extends TaxRulesTaxManagerCore
 		}
 
 		if ( null === $tax_enabled ) {
-			$tax_enabled = Configuration::get('PS_TAX');
+			$tax_enabled = Configuration::get( 'PS_TAX' );
+		}
 
+		if ( $tax_enabled ) {
 			/** @var Vatchecker $vatchecker */
-			$vatchecker    = Module::getInstanceByName('vatchecker');
+			$vatchecker = Module::getInstanceByName('vatchecker');
 			if ( $vatchecker ) {
 
 				// Check if the customer is part of the no TAX group.

--- a/vatchecker.php
+++ b/vatchecker.php
@@ -417,7 +417,10 @@ class Vatchecker extends Module
 			return;
 		}
 
-		$vatValid = $this->isValidVat( $address, true );
+		$vatValid = false;
+		if ( ! $this->isOriginCountry( $address->id_country ) ) {
+			$vatValid = $this->isValidVat( $address, true );
+		}
 
 		if ( null === $vatValid ) {
 			// Module inactive or VIES server offline.

--- a/vatchecker.php
+++ b/vatchecker.php
@@ -814,6 +814,20 @@ class Vatchecker extends Module
 	}
 
 	/**
+	 * @param Address|int $address
+	 * @return Address|null
+	 */
+	public function getAddress( $address ) {
+		if ( is_numeric( $address ) ) {
+			$address = new Address( $address );
+		}
+		if ( $address instanceof Address ) {
+			return $address;
+		}
+		return null;
+	}
+
+	/**
 	 * @since 1.1.1
 	 * @param bool|string $vatValid
 	 * @param int         $countryId

--- a/vatchecker.php
+++ b/vatchecker.php
@@ -463,6 +463,10 @@ class Vatchecker extends Module
 			return null;
 		}
 
+		if ( ! is_string( $vatNumber ) || 8 > strlen( $vatNumber ) ) {
+			return false;
+		}
+
 		if ( is_numeric( $countryCode ) ) {
 			$countryCode = Country::getIsoById( $countryCode );
 		}
@@ -471,7 +475,7 @@ class Vatchecker extends Module
 			return $this->l('Please select an EU country');
 		}
 
-		$vatNumber = str_replace( $countryCode, "", $vatNumber);
+		$vatNumber = ltrim( $vatNumber, $countryCode );
 		return $this->checkVies( $countryCode, $vatNumber );
 	}
 

--- a/vatchecker.php
+++ b/vatchecker.php
@@ -445,6 +445,7 @@ class Vatchecker extends Module
 			return true;
 		}
 
+		/** @var CustomerAddressFormCore $form */
 		$form       = $params['form'];
 		$countryId  = $form->getField('id_country')->getValue();
 		if ( ! $form->getField('vat_number') ) {

--- a/vatchecker.php
+++ b/vatchecker.php
@@ -405,7 +405,7 @@ class Vatchecker extends Module
 		$vatValid = $this->checkVat( $vatNumber, $countryId );
 
 		if ( null === $vatValid ) {
-			// Module inactive.
+			// Module inactive or VIES server offline.
 			return;
 		}
 
@@ -437,7 +437,7 @@ class Vatchecker extends Module
 		$vatValid = $this->checkVat( $vatNumber, $countryId );
 
 		if ( null === $vatValid ) {
-			// Module inactive.
+			// Module inactive or VIES server offline.
 			return true;
 		}
 

--- a/vatchecker.php
+++ b/vatchecker.php
@@ -470,6 +470,23 @@ class Vatchecker extends Module
 	}
 
 	/**
+	 * Check if an address can order without VAT.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param Address $address
+	 *
+	 * @return bool
+	 */
+	public function canOrderWithoutVat( $address ) {
+		if ( $this->isOriginCountry( $address->id_country ) ) {
+			return false;
+		}
+
+		return $this->isValidVat( $address, false );
+	}
+
+	/**
 	 * Check if a VAT number is valid using the address data.
 	 *
 	 * @param Address|array $params {

--- a/vatchecker.php
+++ b/vatchecker.php
@@ -578,20 +578,7 @@ class Vatchecker extends Module
 		}
 
 		// Only one result.
-		$result = reset( $result );
-
-		$db_id_address = (int) $result['id_address'];
-		$db_id_country = (int) $result['id_country'];
-		$db_vat_number = $result['vat_number'];
-
-		if (
-			$addressId != $db_id_address ||
-			$countryId != $db_id_country ||
-			$vatNumber != $db_vat_number
-		) {
-			return null;
-		}
-		return $result;
+		return reset( $result );
 	}
 
 	/**

--- a/vatchecker.php
+++ b/vatchecker.php
@@ -591,10 +591,10 @@ class Vatchecker extends Module
 	 *
 	 * @param array $record {
 	 *     @type int    id_vatchecker
-	 *     @type int    id_address
-	 *     @type int    id_country
+	 *     @type int    id_address (Required)
+	 *     @type int    id_country (Required)
 	 *     @type string company
-	 *     @type string vat_number
+	 *     @type string vat_number (Required)
 	 *     @type bool   valid
 	 *     @type string date_add
 	 *     @type string date_modified
@@ -605,6 +605,15 @@ class Vatchecker extends Module
 	 */
 	private function setVatValidation( $record ) {
 		$table = _DB_PREFIX_ . 'vatchecker';
+
+		// Required fields.
+		if (
+			empty( $record['id_address'] ) ||
+			empty( $record['id_country'] ) ||
+			empty( $record['vat_number'] )
+		) {
+			return false;
+		}
 
 		if ( empty( $record['id_vatchecker'] ) ) {
 			$exists = $this->getVatValidation( $record['id_address'] );

--- a/vatchecker.php
+++ b/vatchecker.php
@@ -534,6 +534,13 @@ class Vatchecker extends Module
 	private function setVatValidation( $record ) {
 		$table = _DB_PREFIX_ . 'vatchecker';
 
+		if ( empty( $record['id_vatchecker'] ) ) {
+			$exists = $this->getVatValidation( $record['id_address'], $record['id_country'], $record['vat_number'] );
+			if ( $exists ) {
+				$record['id_vatchecker'] = $exists['id_vatchecker'];
+			}
+		}
+
 		$keys = array();
 		$values = array();
 		foreach ( $record as $key => $value ) {

--- a/vatchecker.php
+++ b/vatchecker.php
@@ -541,6 +541,15 @@ class Vatchecker extends Module
 			}
 		}
 
+		$today = date( 'Y-m-d H:i:s' );
+		$result['date_modified'] = $today;
+		if ( $result['valid'] ) {
+			$result['date_valid_vat'] = $today;
+		}
+		if ( ! $result['date_add'] ) {
+			$result['date_add'] = $today;
+		}
+
 		$keys = array();
 		$values = array();
 		foreach ( $record as $key => $value ) {

--- a/vatchecker.php
+++ b/vatchecker.php
@@ -471,6 +471,50 @@ class Vatchecker extends Module
 	}
 
 	/**
+	 * @throws PrestaShopDatabaseException
+	 *
+	 * @param $countryId
+	 * @param $vatNumber
+	 * @param $addressId
+	 *
+	 * @return false|mixed|null
+	 */
+	private function getVatValidation( $addressId, $countryId, $vatNumber ) {
+		if ( ! $addressId || ! $countryId || ! $vatNumber ) {
+			return null;
+		}
+
+		$table = _DB_PREFIX_ . 'vatchecker';
+
+		$sql = "SELECT * FROM {$table}
+			WHERE id_address = {$addressId}
+			    AND id_country = {$countryId}
+			    AND vat_number = {$vatNumber}
+			";
+
+		$result = Db::getInstance()->executeS( $sql );
+		if ( empty( $result ) ) {
+			return null;
+		}
+
+		// Only one result.
+		$result = reset( $result );
+
+		$db_id_address = (int) $result['id_address'];
+		$db_id_country = (int) $result['id_country'];
+		$db_vat_number = $result['vat_number'];
+
+		if (
+			$addressId != $db_id_address ||
+			$countryId != $db_id_country ||
+			$vatNumber != $db_vat_number
+		) {
+			return null;
+		}
+		return $result;
+	}
+
+	/**
 	 * @since 1.1.0
 	 * @param string     $vatNumber
 	 * @param int|string $countryCode

--- a/vatchecker.php
+++ b/vatchecker.php
@@ -421,7 +421,7 @@ class Vatchecker extends Module
 			return;
 		}
 
-		$vatValid = $this->checkVat( $vatNumber, $countryId );
+		$vatValid = $this->isValidVat( $address );
 
 		if ( null === $vatValid ) {
 			// Module inactive or VIES server offline.

--- a/vatchecker.php
+++ b/vatchecker.php
@@ -515,6 +515,55 @@ class Vatchecker extends Module
 	}
 
 	/**
+	 * @throws PrestaShopDatabaseException
+	 *
+	 * @param array $record {
+	 *     @type int    id_vatchecker
+	 *     @type int    id_address
+	 *     @type int    id_country
+	 *     @type string company
+	 *     @type string vat_number
+	 *     @type bool   valid
+	 *     @type string date_add
+	 *     @type string date_modified
+	 *     @type string date_valid_vat
+	 * }
+	 *
+	 * @return array|bool|mysqli_result|PDOStatement|resource|null
+	 */
+	private function setVatValidation( $record ) {
+		$table = _DB_PREFIX_ . 'vatchecker';
+
+		$keys = array();
+		$values = array();
+		foreach ( $record as $key => $value ) {
+			$keys[ $key ] = "`{$key}`";
+			if ( is_bool( $value ) ) {
+				$values[ $key ] = (int) $value;
+			} else {
+				$values[ $key ] = "'{$value}'";
+			}
+		}
+
+		if ( ! empty( $record['id_vatchecker'] ) ) {
+			// Update.
+			$id = (int) $record['id_vatchecker'];
+			foreach ( $values as $key => $value ) {
+				$values = $keys[ $key ] . ' = ' . $value;
+			}
+			$values = implode( ', ', $values );
+			$sql    = "UPDATE {$table} SET {$values} WHERE id_vatchecker = {$id}";
+		} else {
+			// Insert.
+			$keys   = implode( ', ', $keys );
+			$values = implode( ', ', $values );
+			$sql    = 'INSERT INTO {$table} ({$keys}) VALUES ({$values})';
+		}
+
+		return Db::getInstance()->executeS( $sql );
+	}
+
+	/**
 	 * @since 1.1.0
 	 * @param string     $vatNumber
 	 * @param int|string $countryCode

--- a/vatchecker.php
+++ b/vatchecker.php
@@ -412,7 +412,7 @@ class Vatchecker extends Module
 		$countryId = $address->id_country;
 		$vatNumber = $address->vat_number;
 
-		$cache_key = $countryId . $vatNumber;
+		$cache_key = $address_id;
 
 		if ( isset( $cache[ $cache_key ] ) ) {
 			$vatValid = true === $cache[ $cache_key ];

--- a/vatchecker.php
+++ b/vatchecker.php
@@ -602,7 +602,7 @@ class Vatchecker extends Module
 		$table = _DB_PREFIX_ . 'vatchecker';
 
 		if ( empty( $record['id_vatchecker'] ) ) {
-			$exists = $this->getVatValidation( $record['id_address'], $record['id_country'], $record['vat_number'] );
+			$exists = $this->getVatValidation( $record['id_address'] );
 			if ( $exists ) {
 				$record['id_vatchecker'] = $exists['id_vatchecker'];
 			}

--- a/vatchecker.php
+++ b/vatchecker.php
@@ -417,7 +417,7 @@ class Vatchecker extends Module
 			return;
 		}
 
-		$vatValid = $this->isValidVat( $address );
+		$vatValid = $this->isValidVat( $address, true );
 
 		if ( null === $vatValid ) {
 			// Module inactive or VIES server offline.
@@ -475,10 +475,11 @@ class Vatchecker extends Module
 	 *     @type int     $countryId
 	 *     @type string  $vatNumber
 	 * }
+	 * @param bool $error Return error (if any) instead of boolean.
 	 *
-	 * @return bool
+	 * @return bool|string Optionally returns string on error if errors are enabled.
 	 */
-	public function isValidVat( $params ) {
+	public function isValidVat( $params, $error = false ) {
 		if ( $params instanceof Address) {
 			$address   = $params;
 			$addressId = $address->id;
@@ -544,8 +545,14 @@ class Vatchecker extends Module
 		if ( is_bool( $vatCheck ) ) {
 			$result['valid'] = $vatCheck;
 			$this->setVatValidation( $result );
+
+			return $vatCheck;
 		}
 
+		if ( ! $error ) {
+			// Convert null to true: module offline.
+			return null === $vatCheck;
+		}
 		return $vatCheck;
 	}
 

--- a/vatchecker.php
+++ b/vatchecker.php
@@ -67,7 +67,7 @@ class Vatchecker extends Module
 	{
 		$this->name = 'vatchecker';
 		$this->tab = 'billing_invoicing';
-		$this->version = '1.2.3';
+		$this->version = '1.3.0';
 		$this->author = 'Inform-All';
 		$this->need_instance = 1;
 
@@ -107,6 +107,10 @@ class Vatchecker extends Module
 			$this->registerHook('actionCartSave');
 	}
 
+	/**
+	 * @since 1.3.0
+	 * @return bool
+	 */
 	public function installDB()
 	{
 		$sql = 'CREATE TABLE IF NOT EXISTS `'._DB_PREFIX_.'vatchecker'.'` (
@@ -495,6 +499,8 @@ class Vatchecker extends Module
 	/**
 	 * Check if a VAT number is valid using the address data.
 	 *
+	 * @since 1.3.0
+	 *
 	 * @param Address $address
 	 * @param bool $error Return error (if any) instead of boolean.
 	 *
@@ -527,6 +533,7 @@ class Vatchecker extends Module
 			if ( strtotime( $result['date_modified'] ) > strtotime( '-1 day' ) ) {
 				return (bool) $result['valid'];
 			}
+
 		} else {
 			$result = array(
 				'id_address'     => $address->id,
@@ -558,6 +565,10 @@ class Vatchecker extends Module
 	}
 
 	/**
+	 * Get VAT validation from the database.
+	 *
+	 * @since 1.3.0
+	 *
 	 * @throws PrestaShopDatabaseException
 	 *
 	 * @param Address $address
@@ -588,6 +599,10 @@ class Vatchecker extends Module
 	}
 
 	/**
+	 * Update/Set VAT validation in the database.
+	 *
+	 * @since 1.3.0
+	 *
 	 * @throws PrestaShopDatabaseException
 	 *
 	 * @param array $record {
@@ -632,7 +647,7 @@ class Vatchecker extends Module
 			$result['date_add'] = $today;
 		}
 
-		$keys = array();
+		$keys   = array();
 		$values = array();
 		foreach ( $record as $key => $value ) {
 			$keys[ $key ] = "`{$key}`";
@@ -663,10 +678,13 @@ class Vatchecker extends Module
 
 	/**
 	 * @since 1.1.0
+	 *
 	 * @param string     $vatNumber
 	 * @param int|string $countryCode
-	 * @param bool       $error  Return error string?
-	 * @return bool|null
+	 * @param bool       $error  Return error string if errored?
+	 *
+	 * @return bool|null|string Optionally returns string on error if errors are enabled.
+	 *                          Otherwise a boolean or null (disabled).
 	 */
 	public function checkVat( $vatNumber, $countryCode = null, $error = true ) {
 
@@ -703,9 +721,11 @@ class Vatchecker extends Module
 
 	/**
 	 * @since 1.0
+	 *
 	 * @param string $countryCode
 	 * @param string $vatNumber
-	 * @return bool|string
+	 *
+	 * @return bool|null|string
 	 */
 	protected function checkVies( $countryCode, $vatNumber )
 	{

--- a/vatchecker.php
+++ b/vatchecker.php
@@ -407,16 +407,12 @@ class Vatchecker extends Module
 			return;
 		}
 
-		$address = new Address( $address_id );
-
-		$countryId = $address->id_country;
-		$vatNumber = $address->vat_number;
-
+		$address   = new Address( $address_id );
 		$cache_key = $address_id;
 
 		if ( isset( $cache[ $cache_key ] ) ) {
 			$vatValid = true === $cache[ $cache_key ];
-			$this->updateNoTaxGroup( $vatValid, $countryId, $this->context->customer );
+			$this->updateNoTaxGroup( $vatValid, $address->id_country, $this->context->customer );
 
 			return;
 		}
@@ -430,7 +426,7 @@ class Vatchecker extends Module
 
 		$vatValid = true === $vatValid;
 
-		$this->updateNoTaxGroup( $vatValid, $countryId, $this->context->customer );
+		$this->updateNoTaxGroup( $vatValid, $address->id_country, $this->context->customer );
 
 		$cache[ $cache_key ] = $vatValid;
 	}

--- a/vatchecker.php
+++ b/vatchecker.php
@@ -529,6 +529,17 @@ class Vatchecker extends Module
 			if ( strtotime( $result['date_modified'] ) > strtotime( '-1 day' ) ) {
 				return (bool) $result['valid'];
 			}
+		} else {
+			$result = array(
+				'id_address'     => $addressId,
+				'id_country'     => $countryId,
+				'company'        => $address->company,
+				'vat_number'     => $vatNumber,
+				'valid'          => false,
+				'date_add'       => '',
+				'date_modified'  => '',
+				'date_valid_vat' => '',
+			);
 		}
 
 		$vatCheck = $this->checkVat( $vatNumber, $countryId );

--- a/vatchecker.php
+++ b/vatchecker.php
@@ -100,10 +100,29 @@ class Vatchecker extends Module
 		//Configuration::updateValue('VATCHECKER_NO_TAX_GROUP', null);
 
 		return parent::install() &&
+			$this->installDB() &&
 			$this->registerHook('displayHeader') &&
 			$this->registerHook('displayBeforeBodyClosingTag') &&
 			$this->registerHook('actionValidateCustomerAddressForm') &&
 			$this->registerHook('actionCartSave');
+	}
+
+	public function installDB()
+	{
+		$sql = 'CREATE TABLE IF NOT EXISTS `'._DB_PREFIX_.'vatchecker'.'` (
+			`id_vatchecker` int(12) UNSIGNED NOT NULL AUTO_INCREMENT,
+			`id_address` INTEGER UNSIGNED NOT NULL,
+			`id_country` INTEGER UNSIGNED NOT NULL,
+			`company` varchar(255) default \'\',
+			`vat_number` varchar(32) NOT NULL,
+			`valid` int(1) UNSIGNED NOT NULL,
+			`date_add` datetime NOT NULL,
+			`date_modified` datetime NOT NULL,
+			`date_valid_vat` datetime,
+			PRIMARY KEY(`id`)
+		) ENGINE='._MYSQL_ENGINE_.' DEFAULT CHARSET=utf8';
+
+		return Db::getInstance()->execute($sql);
 	}
 
 	public function uninstall()

--- a/vatchecker.php
+++ b/vatchecker.php
@@ -455,16 +455,17 @@ class Vatchecker extends Module
 	 * @since 1.1.0
 	 * @param string     $vatNumber
 	 * @param int|string $countryCode
+	 * @param bool       $error  Return error string?
 	 * @return bool|null
 	 */
-	public function checkVat( $vatNumber, $countryCode = null ) {
+	public function checkVat( $vatNumber, $countryCode = null, $error = true ) {
 
 		if ( ! Configuration::get( 'VATCHECKER_LIVE_MODE' ) ) {
 			return null;
 		}
 
 		if ( ! is_string( $vatNumber ) || 8 > strlen( $vatNumber ) ) {
-			return false;
+			return ( $error ) ? $this->l('VAT number format invalid') : false;
 		}
 
 		if ( is_numeric( $countryCode ) ) {
@@ -472,7 +473,7 @@ class Vatchecker extends Module
 		}
 
 		if ( ! $this->isEUCountry( $countryCode ) ) {
-			return $this->l('Please select an EU country');
+			return ( $error ) ? $this->l('Please select an EU country') : false;
 		}
 
 		$vatNumber = ltrim( $vatNumber, $countryCode );

--- a/vatchecker.php
+++ b/vatchecker.php
@@ -502,6 +502,10 @@ class Vatchecker extends Module
 			$vatNumber = $params['vatNumber'];
 			$countryId = $params['countryId'];
 			$addressId = ! empty( $params['addressId'] ) ? $params['addressId'] : '';
+			if ( ! $addressId ) {
+				// Check VAT without DB storage.
+				return $this->checkVat( $vatNumber, $countryId );
+			}
 			$address = new Address( $addressId );
 		}
 

--- a/vatchecker.php
+++ b/vatchecker.php
@@ -477,7 +477,18 @@ class Vatchecker extends Module
 		}
 
 		$vatNumber = ltrim( $vatNumber, $countryCode );
-		return $this->checkVies( $countryCode, $vatNumber );
+
+		$valid = $this->checkVies( $countryCode, $vatNumber );
+		if ( is_bool( $valid ) ) {
+			if ( ! $valid && $error ) {
+				// VIES validation returned false.
+				$valid = $this->l('This is not a valid VAT number');
+			}
+		} elseif ( is_string( $valid ) && ! $error ) {
+			// Convert VIES validation error to false.
+			$valid = false;
+		}
+		return $valid;
 	}
 
 	/**
@@ -502,11 +513,11 @@ class Vatchecker extends Module
 			if ( $result->valid === true ) {
 				return true;
 			}
-			return $this->l('This is not a valid VAT number');
+			return false;
 
 		} catch ( Throwable $e ) {
 			if ( Configuration::get( 'VATCHECKER_ALLOW_OFFLINE' ) ) {
-				return true;
+				return null;
 			}
 			return $this->l( 'EU VIES server not responding' );
 		}

--- a/vatchecker.php
+++ b/vatchecker.php
@@ -479,6 +479,11 @@ class Vatchecker extends Module
 	 * @return bool
 	 */
 	public function canOrderWithoutVat( $address ) {
+		$address = $this->getAddress( $address );
+		if ( ! $address ) {
+			return false;
+		}
+
 		if ( $this->isOriginCountry( $address->id_country ) ) {
 			return false;
 		}


### PR DESCRIPTION
This PR will update this plugin to store all validations into the database.
If a VIES call was successful it will store a new record into the database based on the address id, country id and vat number.
These records will contain whether the VAT number is valid, when it was checked and if it is invalid, when it was last checked as valid.
Whether the customer can buy without TAX is after this PR not depending on the user group but on the VAT validation stored in the database based on the address.

At the point of writing this I still kept the user groups active for administration purposes.