### PR TITLE
North Ireland add

### DIFF
--- a/vatchecker.php
+++ b/vatchecker.php
@@ -79,6 +79,7 @@ class Vatchecker extends Module
 		'SE' => '(SE)?[0-9]{12}',                              # Sweden
 		'SI' => '(SI)?[0-9]{8}',                               # Slovenia
 		'SK' => '(SK)?[0-9]{10}',                              # Slovakia
+		'XI' => '(XI)?([0-9]{9}([0-9]{3})?|[A-Z]{2}[0-9]{3})'  # North Ireland
 	);
 
 	/**


### PR DESCRIPTION
North Ireland (XI) has the same syntax of GB.

EU directive n. 2020/1756 del 20 novembre 2020 specify that the North Ireland will have a bew XIU identification code instaed of GB and will be managed as a EU state so Taxes must be applied when is aprivate or not VIES validated VAT code.

<<Under Brexit, Northern Ireland (NI) has adopted a dual status and is considered part of both the EU and the UK tax regimes.

If you use [registration-based tax settings](https://help.shopify.com/en/manual/taxes/registration), then VAT is calculated based on the order's origin and its destination. UK VAT applies to orders from within the United Kingdom to customers in Northern Ireland, and to orders from within Northern Ireland to customers in the United Kingdom. EU VAT applies to orders from within the European Union to customers in Northern Ireland, and to orders from within Northern Ireland to customers in the European Union.>>