### PR TITLE
Mention soap extension requirement in readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -9,6 +9,10 @@ If a customer is not from the EU, nothing will happen.
 If a  customer is from the same country as your shop, nothing will happen.
 This module is made according to the european intra-Community supply rules.
 
+## Requirements
+
+- [SOAP PHP extension](https://www.php.net/manual/en/book.soap.php)
+
 ---
 
 Feel free to update / add functions to the module.


### PR DESCRIPTION
This plugin requires php-soap and doesn't specify it anywhere.