### PR TITLE
Backwards compatibility fix and UI enhancement for 2.1

### DIFF
--- a/vatchecker.php
+++ b/vatchecker.php
@@ -337,20 +337,32 @@ class Vatchecker extends Module
 						],
 					],
 					[
-						'type'    => 'select',
+						'type'    => 'radio',
 						'label'   => $this->l( 'Offline validation' ),
 						'name'    => 'VATCHECKER_ALLOW_OFFLINE',
 						'required' => false,
 						'desc'    => $this->l( 'What logic should the module use when the VIES database is offline?' ),
-						'options' => [
-							'query' => [
-								['id'=>0,'name'=>"Always mark VAT as invalid"],
-								['id'=>1,'name'=>"Always mark VAT as valid"],
-								['id'=>2,'name'=>"Use previous validation value, if not previously validated mark VAT invalid"],
-								['id'=>3,'name'=>"Use previous validation value, if not previously validated mark VAT valid"]
+						'values' => [
+							[
+								'id' => 'invalid',
+								'value' => 0,
+								'label' => $this->l('Always mark VAT as invalid')
 							],
-							'id' => 'id',
-							'name' => 'name',
+							[
+								'id' => 'valid',
+								'value' => 1,
+								'label' => $this->l('Always mark VAT as valid')
+							],
+							[
+								'id' => 'exists_invalid',
+								'value' => 2,
+								'label' => $this->l('Use previous validation value, if not previously validated mark VAT as invalid')
+							],
+							[
+								'id' => 'exists_valid',
+								'value' => 3,
+								'label' => $this->l('Use previous validation value, if not previously validated mark VAT as valid')
+							]
 						],
 					],
 					[

--- a/vatchecker.php
+++ b/vatchecker.php
@@ -344,10 +344,10 @@ class Vatchecker extends Module
 						'desc'    => $this->l( 'What logic should the module use when the VIES database is offline?' ),
 						'options' => [
 							'query' => [
+								['id'=>0,'name'=>"Always mark VAT as invalid"],
 								['id'=>1,'name'=>"Always mark VAT as valid"],
-								['id'=>2,'name'=>"Always mark VAT as invalid"],
-								['id'=>3,'name'=>"Use previous address logic, if none mark VAT valid"],
-								['id'=>4,'name'=>"Use previous address logic, if none mark VAT invalid"]
+								['id'=>2,'name'=>"Use previous validation value, if not previously validated mark VAT invalid"],
+								['id'=>3,'name'=>"Use previous validation value, if not previously validated mark VAT valid"]
 							],
 							'id' => 'id',
 							'name' => 'name',
@@ -818,7 +818,6 @@ class Vatchecker extends Module
 			$return['error'] = $this->l( 'EU VIES server not responding' );
 			$return['valid'] = $this->VIESOfflineLogicHander($params);
 
-
 			PrestaShopLogger::addLog( 'VAT check failed! (params: ' . implode( ', ', $params ) . ' , error: ' . $e->getMessage() . ')', ERROR_SEVERITY );
 		}
 
@@ -829,24 +828,18 @@ class Vatchecker extends Module
 
 	public function VIESOfflineLogicHander($params)
 	{
-		switch (Configuration::get( 'VATCHECKER_ALLOW_OFFLINE' )) {
+		switch ( Configuration::get( 'VATCHECKER_ALLOW_OFFLINE' ) ) {
 			case 1:
+			case true:
 				return true;
-			break;
 			case 2:
-				return false;
-			break;
+				$previous =  $this->getPreviousValidation($params);
+				return (!empty($previous)) ? $previous->valid : false;
 			case 3:
 				$previous =  $this->getPreviousValidation($params);
 				return (!empty($previous)) ? $previous->valid : true;
-			break;
-			case 4:
-				$previous =  $this->getPreviousValidation($params);
-				return (!empty($previous)) ? $previous->valid : false;
-			break;
-			default:
-				return false;
 		}
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
- [Make offline setting compatible with existing switch](https://github.com/NKoonen/vatchecker/commit/f94e539b1d153271a340e750e8f5304772c21568)

The old config option used true (1) for enabled and false (0) for disabled. This change reflects the same behavior so users won't need to manually update their config after updating this plugin.

- [Convert to radio and add translations](https://github.com/NKoonen/vatchecker/commit/1be9997819ed28b09c71ce4d69e44fbb6878a015)