### PR TITLE
QuickFix: function isEUCountry( $countryCode ) 

### DIFF
--- a/vatchecker.php
+++ b/vatchecker.php
@@ -942,6 +942,7 @@ class Vatchecker extends Module
 	{
 		$key = 'iso_code';
 		if ( is_numeric( $countryCode ) ) {
+			$countryCode = intval($countryCode);
 			$key = 'id_country';
 		}
 		foreach ( $this->getEUCountries() as $country ) {


### PR DESCRIPTION
There is an issue when function isEUCountry is provided with $countryCode that is numeric but provided as string.

This is a QuickFix for that issue.