### PR TITLE
Validate VAT ID for non VIES Registered Entities

### DIFF
--- a/vatchecker.php
+++ b/vatchecker.php
@@ -476,6 +476,12 @@ class Vatchecker extends Module
 		}
 
 		if ( true !== $vatValid ) {
+
+			// If it's not a VIES Valid but an actually customer Tax Id / VAT Number
+		    	if($vatError === 'This is not a valid VAT number') {
+		        	return true;
+		    	}
+			
 			$form->getField( 'vat_number' )->addError( $vatError );
 
 			return false;


### PR DESCRIPTION
It is possible that a customer or company is not registered in VIES, but their VAT number is still valid. 

In this way the form address will be validated but the tax behaviour will not be updated.